### PR TITLE
Fix index route helper

### DIFF
--- a/lib/tasks/bunko_tasks.rake
+++ b/lib/tasks/bunko_tasks.rake
@@ -219,8 +219,8 @@ namespace :bunko do
     render_template("index.html.erb.tt", {
       collection_name: collection_name,
       collection_title: collection_name.titleize,
-      path_helper: "#{collection_name}_path",
-      index_path_helper: "#{collection_name}_index_path"
+      path_helper: "#{collection_name.singularize}_path",
+      index_path_helper: "#{collection_name}_path"
     })
   end
 
@@ -228,7 +228,7 @@ namespace :bunko do
     render_template("show.html.erb.tt", {
       collection_name: collection_name,
       collection_title: collection_name.titleize,
-      index_path_helper: "#{collection_name}_index_path"
+      index_path_helper: "#{collection_name}_path"
     })
   end
 

--- a/test/tasks/bunko_setup_task_test.rb
+++ b/test/tasks/bunko_setup_task_test.rb
@@ -109,10 +109,10 @@ class BunkoSetupTaskTest < Minitest::Test
     # Verify view content
     index_view = File.read(File.join(@destination, "app/views/blog/index.html.erb"))
     assert_match(/class="blog-index"/, index_view)
-    assert_match(/blog_path/, index_view)
+    assert_match(/blog_path/, index_view) # Both index pagination and show links use blog_path
 
     show_view = File.read(File.join(@destination, "app/views/blog/show.html.erb"))
-    assert_match(/blog_index_path/, show_view)
+    assert_match(/blog_path/, show_view) # Back link uses blog_path (Rails convention)
   end
 
   def test_setup_adds_routes_for_each_post_type


### PR DESCRIPTION
- Use `collection_name_path` for index pagination (not `collection_name_index_path`)
   - Use `collection_name.singularize_path` for show links
   - Follows Rails resourceful routing conventions

   Fixes issue where plural collections like `:case_studies` generated
   invalid helpers like `case_studies_index_path`.
