### PR TITLE
Override route helpers instead of to_param

### DIFF
--- a/lib/bunko/configuration.rb
+++ b/lib/bunko/configuration.rb
@@ -42,6 +42,7 @@ module Bunko
     end
 
     attr_accessor :reading_speed, :excerpt_length, :auto_update_word_count, :valid_statuses, :post_types, :collections, :allow_static_pages
+    attr_reader :collection_path_helpers
 
     def initialize
       @reading_speed = 250 # words per minute
@@ -51,6 +52,12 @@ module Bunko
       @post_types = [] # Must be configured in initializer
       @collections = [] # Multi-type collections
       @allow_static_pages = true # Enable standalone pages feature by default
+      @collection_path_helpers = [] # Track which path helpers to override
+    end
+
+    # Register a collection path helper for override (called by routing DSL)
+    def register_path_helper(resource_name)
+      @collection_path_helpers << resource_name.to_s unless @collection_path_helpers.include?(resource_name.to_s)
     end
 
     def post_type(name, title: nil, &block)

--- a/lib/bunko/helpers/collection_path_helpers.rb
+++ b/lib/bunko/helpers/collection_path_helpers.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Bunko
+  module Helpers
+    # Dynamically overrides path helpers for Bunko collections to automatically extract slugs
+    # from Post objects, making link generation ergonomic: blog_path(@post) instead of blog_path(@post.slug)
+    module CollectionPathHelpers
+      def self.install!
+        # Generate override methods for each registered collection
+        Bunko.configuration.collection_path_helpers.each do |resource_name|
+          define_path_helper_override(resource_name)
+        end
+      end
+
+      def self.define_path_helper_override(resource_name)
+        # Override both _path and _url helpers
+        define_method "#{resource_name}_path" do |post_or_slug = nil, *args|
+          if post_or_slug.respond_to?(:slug)
+            # It's a Post object - extract the slug
+            super(post_or_slug.slug, *args)
+          else
+            # It's already a slug string, or nil for index route
+            super(post_or_slug, *args)
+          end
+        end
+
+        define_method "#{resource_name}_url" do |post_or_slug = nil, *args|
+          if post_or_slug.respond_to?(:slug)
+            # It's a Post object - extract the slug
+            super(post_or_slug.slug, *args)
+          else
+            # It's already a slug string, or nil for index route
+            super(post_or_slug, *args)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bunko/models/post_methods.rb
+++ b/lib/bunko/models/post_methods.rb
@@ -32,9 +32,6 @@ module Bunko
       end
 
       # Instance methods
-      def to_param
-        slug
-      end
 
       def excerpt(length: nil, omission: "...")
         return nil unless content.present?

--- a/lib/bunko/railtie.rb
+++ b/lib/bunko/railtie.rb
@@ -12,6 +12,23 @@ module Bunko
       end
     end
 
+    # Install path helper overrides after routes are loaded
+    # This allows blog_path(@post) to automatically extract slug
+    config.after_initialize do
+      require "bunko/helpers/collection_path_helpers"
+
+      # Install helper overrides in both views and controllers
+      ActiveSupport.on_load(:action_view) do
+        include Bunko::Helpers::CollectionPathHelpers
+        Bunko::Helpers::CollectionPathHelpers.install!
+      end
+
+      ActiveSupport.on_load(:action_controller) do
+        include Bunko::Helpers::CollectionPathHelpers
+        Bunko::Helpers::CollectionPathHelpers.install!
+      end
+    end
+
     rake_tasks do
       load "tasks/bunko/install.rake"
       load "tasks/bunko/setup.rake"

--- a/lib/bunko/routing/mapper_methods.rb
+++ b/lib/bunko/routing/mapper_methods.rb
@@ -41,6 +41,9 @@ module Bunko
           path_value = collection_name.to_s.tr("_", "-")
         end
 
+        # Register this resource for path helper override (so blog_path(@post) works ergonomically)
+        Bunko.configuration.register_path_helper(resource_name)
+
         # Define the routes
         resources resource_name,
           controller: controller,

--- a/test/models/post_slug_test.rb
+++ b/test/models/post_slug_test.rb
@@ -95,17 +95,6 @@ class PostSlugTest < ActiveSupport::TestCase
     assert_equal "custom-slug", post.slug
   end
 
-  test "to_param returns slug for URL generation" do
-    post = Post.create!(
-      title: "Hello World",
-      content: "Content",
-      post_type: @blog_type
-    )
-
-    assert_equal post.slug, post.to_param
-    assert_equal "hello-world", post.to_param
-  end
-
   test "slug generation skips when title is blank" do
     post = Post.new(post_type: @blog_type)
     post.send(:generate_slug)


### PR DESCRIPTION
Implements scoped path helper overrides for Bunko-managed collection routes, allowing ergonomic usage (blog_path(@post)) without affecting admin/CMS routes.

  **Problem**

  Previous Approach: Override to_param to return slug
  - ✅ Clean syntax everywhere: blog_path(@post), edit_post_path(@post)
  - ❌ Global override - affects ALL routes (admin, API, etc.)
  - ❌ Admin interfaces forced to use slugs instead of IDs
  - ❌ Slugs can change, making admin work less reliable

  User Need:
  - Public collection routes should use slugs: /blog/my-post-slug
  - Admin/CMS routes should use IDs: /posts/123/edit
  - View helpers should be ergonomic: blog_path(@post) not blog_path(@post.slug)

  **Solution**

  Hijack only Bunko-controlled path helpers by dynamically overriding them at route-load time:
```
  # lib/bunko/helpers/collection_path_helpers.rb
  def blog_path(post_or_slug = nil, *args)
    if post_or_slug.respond_to?(:slug)
      super(post_or_slug.slug, *args)  # Extract slug
    else
      super(post_or_slug, *args)        # Pass through
    end
  end
```
  **Implementation**

  1. Route Registration (lib/bunko/routing/mapper_methods.rb)
    - bunko_collection :blog registers "blog" with Configuration
  2. Configuration Tracking (lib/bunko/configuration.rb)
    - Maintains array of collection path helpers to override
  3. Dynamic Helper Generation (lib/bunko/helpers/collection_path_helpers.rb)
    - Generates _path and _url override methods for each registered collection
    - Uses define_method to create helpers at runtime
  4. Railtie Integration (lib/bunko/railtie.rb)
    - Installs helper overrides in config.after_initialize
    - Includes module in both ActionView and ActionController

  **Result**
```
  # Collection views - ergonomic ✓
  blog_path(@post)          # → /blog/my-post-slug
  docs_path(@post)          # → /docs/my-post-slug

  # Admin views - reliable IDs ✓
  edit_post_path(@post)     # → /posts/123/edit
  admin_post_path(@post)    # → /admin/posts/123

  # Still flexible
  blog_path("custom-slug")  # → /blog/custom-slug
  blog_path                 # → /blog
```
  **Pros vs. Previous Approach**

  Current (Dynamic Helpers):
  - ✅ Scoped - only affects Bunko routes
  - ✅ Admin routes use reliable IDs
  - ✅ Ergonomic in collection views
  - ✅ Non-invasive - doesn't override to_param
  - ✅ Developers retain full control over admin interfaces
  - ⚠️ More complex implementation
  - ⚠️ Magic happens at route-load time (harder to debug)

  Previous (to_param Override):
  - ✅ Simpler implementation
  - ✅ Consistent everywhere (always uses slugs)
  - ✅ Matches friendly_id pattern (widely understood)
  - ❌ Global override affects all routes
  - ❌ Admin forced to use slugs (less reliable)
  - ❌ More opinionated (violates Bunko's lightweight philosophy)

  **Files Changed**

  - lib/bunko/configuration.rb - Add collection_path_helpers tracking
  - lib/bunko/routing/mapper_methods.rb - Register helpers during route definition
  - lib/bunko/helpers/collection_path_helpers.rb - New - Dynamic helper overrides
  - lib/bunko/railtie.rb - Install helpers after initialization
  - lib/bunko/models/post_methods.rb - Remove to_param override


  **Open Questions**

  1. Complexity trade-off: Is the scoped approach worth the added complexity?
  2. Debugging: Helper overrides may be harder to trace than to_param
  3. Alternative: Should we just document that admin interfaces should use find_by(slug:) and keep the simpler to_param approach?

  **Recommendation**

  Consider reverting to to_param approach if:
  - Bunko users primarily use admin gems like Avo/ActiveAdmin (they handle slug lookups)
  - Simplicity > separation of concerns
  - friendly_id pattern is acceptable

  Keep dynamic helpers if:
  - Admin reliability (ID-based) is critical
  - Users build custom admin interfaces
  - Minimal global impact is important