### PR TITLE
Fix how bunko_page route helper fetches post slug

### DIFF
--- a/lib/bunko/routing/mapper_methods.rb
+++ b/lib/bunko/routing/mapper_methods.rb
@@ -46,7 +46,7 @@ module Bunko
         else
           # No custom path - use collection_name for resource name, hyphenate for path
           resource_name = collection_name
-          path_value = collection_name.to_s.tr("_", "-")
+          path_value = collection_name.to_s.dasherize
         end
 
         # Define the routes
@@ -82,19 +82,20 @@ module Bunko
         custom_path = options.delete(:path)
         controller = options.delete(:controller) || "pages"
 
-        # Page slug stored with underscores in database
+        # Convert to underscores for Ruby conventions (route name, helpers)
         slug = page_name.to_s.underscore
 
         # URL path uses hyphens (Rails convention)
-        path_value = custom_path || slug.tr("_", "-")
+        path_value = custom_path || slug.dasherize
 
         # Route name uses underscores for path helpers (e.g., about_path)
         route_name = slug.to_sym
 
         # Define single GET route
+        # Pass hyphenated slug to match Post.slug format in database
         get path_value,
           to: "#{controller}#show",
-          defaults: {page: slug},
+          defaults: {page: slug.dasherize},
           as: route_name
       end
     end

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+class PagesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    # Reset configuration before each test
+    Bunko.reset_configuration!
+    Bunko.configure do |config|
+      config.allow_static_pages = true
+    end
+
+    # Reload routes to pick up the new configuration
+    Rails.application.reload_routes!
+
+    @pages_type = PostType.create!(name: "pages", title: "Pages")
+
+    # Create pages with hyphenated slugs (matching Post.slug auto-generation)
+    @about_page = Post.create!(
+      title: "About Us",
+      slug: "about-us",  # Hyphenated (from parameterize)
+      content: "About our company",
+      post_type: @pages_type,
+      status: "published",
+      published_at: 1.day.ago
+    )
+
+    @privacy_page = Post.create!(
+      title: "Privacy Policy",
+      slug: "privacy-policy",  # Hyphenated (from parameterize)
+      content: "Our privacy policy",
+      post_type: @pages_type,
+      status: "published",
+      published_at: 1.day.ago
+    )
+
+    @terms_page = Post.create!(
+      title: "Terms and Conditions",
+      slug: "terms-and-conditions",  # Hyphenated (from parameterize)
+      content: "Our terms",
+      post_type: @pages_type,
+      status: "published",
+      published_at: 1.day.ago
+    )
+  end
+
+  test "bunko_page finds page with hyphenated slug" do
+    get "/about-us"
+    assert_response :success
+  end
+
+  test "bunko_page with underscored route name finds hyphenated slug" do
+    # Route defined as bunko_page :privacy_policy (underscored)
+    # URL is /privacy-policy (hyphenated)
+    # Database slug is "privacy-policy" (hyphenated)
+    get "/privacy-policy"
+    assert_response :success
+    assert_match "Privacy Policy", response.body
+  end
+
+  test "bunko_page with multi-word underscored route finds hyphenated slug" do
+    # Route defined as bunko_page :terms_and_conditions (underscored)
+    # URL is /terms-and-conditions (hyphenated)
+    # Database slug is "terms-and-conditions" (hyphenated)
+    get "/terms-and-conditions"
+    assert_response :success
+    assert_match "Terms and Conditions", response.body
+  end
+
+  test "bunko_page returns 404 for non-existent page" do
+    get "/non-existent"
+    assert_response :not_found
+  end
+
+  test "bunko_page returns 404 for draft pages" do
+    Post.create!(
+      title: "Draft Page",
+      slug: "draft-page",
+      content: "Draft content",
+      post_type: @pages_type,
+      status: "draft"
+    )
+
+    get "/draft-page"
+    assert_response :not_found
+  end
+
+  # Namespace tests
+  test "bunko_page works inside namespace" do
+    # The namespace route looks for the same pages as non-namespaced routes
+    # It's just a different URL path to reach them
+    # We already have @privacy_page and @terms_page from setup
+
+    get "/legal/privacy-policy"
+    assert_response :success
+    assert_match "Our privacy policy", response.body
+
+    get "/legal/terms-and-conditions"
+    assert_response :success
+    assert_match "Our terms", response.body
+  end
+
+  test "bunko_page in namespace with underscored route name finds hyphenated slug" do
+    # Route defined as: namespace :legal do bunko_page :terms_and_conditions end
+    # Should find Post with slug "terms-and-conditions"
+    # We already have @terms_page from setup with slug "terms-and-conditions"
+
+    get "/legal/terms-and-conditions"
+    assert_response :success
+    assert_match "Terms and Conditions", response.body
+  end
+end

--- a/test/dummy/app/controllers/legal/pages_controller.rb
+++ b/test/dummy/app/controllers/legal/pages_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Legal
+  class PagesController < ApplicationController
+    def show
+      @post = Post.published.find_by(
+        post_type: PostType.find_by(name: "pages"),
+        slug: params[:page]
+      )
+
+      unless @post
+        raise ActiveRecord::RecordNotFound, "Page not found: #{params[:page]}"
+      end
+
+      # Check if a custom view exists for this page
+      # e.g., app/views/legal/pages/privacy_policy.html.erb
+      if template_exists?(params[:page], "legal/pages")
+        render params[:page]
+      else
+        # Otherwise render the default show.html.erb
+        render :show
+      end
+    end
+  end
+end

--- a/test/dummy/app/controllers/pages_controller.rb
+++ b/test/dummy/app/controllers/pages_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class PagesController < ApplicationController
+  def show
+    @post = Post.published.find_by(
+      post_type: PostType.find_by(name: "pages"),
+      slug: params[:page]
+    )
+
+    unless @post
+      raise ActiveRecord::RecordNotFound, "Page not found: #{params[:page]}"
+    end
+
+    # Check if a custom view exists for this page
+    # e.g., app/views/pages/about.html.erb
+    if template_exists?(params[:page], "pages")
+      render params[:page]
+    else
+      # Otherwise render the default show.html.erb
+      render :show
+    end
+  end
+end

--- a/test/dummy/app/views/legal/pages/show.html.erb
+++ b/test/dummy/app/views/legal/pages/show.html.erb
@@ -1,0 +1,2 @@
+<h1><%= @post.title %></h1>
+<div><%= @post.content %></div>

--- a/test/dummy/app/views/pages/show.html.erb
+++ b/test/dummy/app/views/pages/show.html.erb
@@ -1,0 +1,2 @@
+<h1><%= @post.title %></h1>
+<div><%= @post.content %></div>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -19,6 +19,19 @@ Rails.application.routes.draw do
   # All Content (Collection) - for collection routing tests
   bunko_collection :all_content
 
+  # Static pages - for bunko_page routing tests
+  bunko_page :about_us
+  bunko_page :privacy_policy
+  bunko_page :terms_and_conditions
+  bunko_page :draft_page
+  bunko_page :non_existent
+
+  # Namespaced pages - test bunko_page in namespace
+  namespace :legal do
+    bunko_page :privacy_policy
+    bunko_page :terms_and_conditions
+  end
+
   # Test routes for nonexistent PostType
   get "/nonexistent", to: "nonexistent#index", as: :nonexistent_index
   get "/nonexistent/:slug", to: "nonexistent#show", as: :nonexistent


### PR DESCRIPTION
Fixes #22 

**Problem**: bunko_page routes passed underscored slugs to controllers (params[:page] = "privacy_policy"), but Post
  records store hyphenated slugs ("privacy-policy"), causing 404s.

  **Solution**: Changed routing DSL to pass hyphenated slugs using dasherize.

  **Changes**:
  - Updated bunko_page to use slug.dasherize in route defaults (lib/bunko/routing/mapper_methods.rb:98)
  - Added routing tests for hyphenated slug defaults
  - Added integration tests for pages controller
  - Added tests for namespace support (namespace :legal do bunko_page :privacy_policy end)