### PR TITLE
Fix how we fetch page slugs with bunko_page

### DIFF
--- a/lib/tasks/templates/controllers/pages_controller.rb.tt
+++ b/lib/tasks/templates/controllers/pages_controller.rb.tt
@@ -2,19 +2,25 @@
 
 class PagesController < ApplicationController
   def show
+    # Extract page slug from request path (not user-controllable params)
+    # This prevents path traversal attacks via query string manipulation
+    # e.g., GET /about?page=../../admin/users
+    page_slug = request.path.split('/').reject(&:empty?).last
+
     @post = Post.published.find_by(
       post_type: PostType.find_by(name: "pages"),
-      slug: params[:page]
+      slug: page_slug
     )
 
     unless @post
-      raise ActiveRecord::RecordNotFound, "Page not found: #{params[:page]}"
+      raise ActiveRecord::RecordNotFound, "Page not found"
     end
 
     # Check if a custom view exists for this page
+    # Use DB-validated slug to prevent rendering arbitrary templates
     # e.g., app/views/pages/about.html.erb
-    if template_exists?(params[:page], "pages")
-      render params[:page]
+    if template_exists?(@post.slug, "pages")
+      render @post.slug
     else
       # Otherwise render the default show.html.erb
       render :show

--- a/test/dummy/app/controllers/legal/pages_controller.rb
+++ b/test/dummy/app/controllers/legal/pages_controller.rb
@@ -3,19 +3,25 @@
 module Legal
   class PagesController < ApplicationController
     def show
+      # Extract page slug from request path (not user-controllable params)
+      # This prevents path traversal attacks via query string manipulation
+      # e.g., GET /legal/privacy-policy?page=../../admin/users
+      page_slug = request.path.split("/").reject(&:empty?).last
+
       @post = Post.published.find_by(
         post_type: PostType.find_by(name: "pages"),
-        slug: params[:page]
+        slug: page_slug
       )
 
       unless @post
-        raise ActiveRecord::RecordNotFound, "Page not found: #{params[:page]}"
+        raise ActiveRecord::RecordNotFound, "Page not found"
       end
 
       # Check if a custom view exists for this page
+      # Use DB-validated slug to prevent rendering arbitrary templates
       # e.g., app/views/legal/pages/privacy_policy.html.erb
-      if template_exists?(params[:page], "legal/pages")
-        render params[:page]
+      if template_exists?(@post.slug, "legal/pages")
+        render @post.slug
       else
         # Otherwise render the default show.html.erb
         render :show

--- a/test/dummy/app/controllers/pages_controller.rb
+++ b/test/dummy/app/controllers/pages_controller.rb
@@ -2,19 +2,25 @@
 
 class PagesController < ApplicationController
   def show
+    # Extract page slug from request path (not user-controllable params)
+    # This prevents path traversal attacks via query string manipulation
+    # e.g., GET /about?page=../../admin/users
+    page_slug = request.path.split("/").reject(&:empty?).last
+
     @post = Post.published.find_by(
       post_type: PostType.find_by(name: "pages"),
-      slug: params[:page]
+      slug: page_slug
     )
 
     unless @post
-      raise ActiveRecord::RecordNotFound, "Page not found: #{params[:page]}"
+      raise ActiveRecord::RecordNotFound, "Page not found"
     end
 
     # Check if a custom view exists for this page
+    # Use DB-validated slug to prevent rendering arbitrary templates
     # e.g., app/views/pages/about.html.erb
-    if template_exists?(params[:page], "pages")
-      render params[:page]
+    if template_exists?(@post.slug, "pages")
+      render @post.slug
     else
       # Otherwise render the default show.html.erb
       render :show


### PR DESCRIPTION
Addresses #24 

**Problem**

  The PagesController used `params[:page]` for both database lookup and template rendering. Since Rails route
  `defaults` can be overridden via query strings, attackers could manipulate which page loads or which template
  renders:

  ```bash
  GET /about?page=privacy-policy    # Loads wrong page
  GET /about?page=../../admin/users # Attempts to render arbitrary template
```

  **Solution**

  Extract page slug from request.path (immutable) instead of params[:page] (user-controlled):

  `page_slug = request.path.split("/").reject(&:empty?).last`

  This approach should:
  - ✅ Ignore query string manipulation
  - ✅ Handle trailing slashes
  - ✅ Work with namespaces
  - ✅ Use DB-validated slug for template rendering

  **Testing**

  Added 5 security tests verifying:
  - Query string params cannot override page slug
  - Path traversal attempts are ignored
  - Malicious template names are ignored
  - Trailing slashes handled correctly
  - Namespaced routes secured