### PR TITLE
Validate PostType name format and use public_send in generated views

### DIFF
--- a/lib/bunko/models/post_type_methods.rb
+++ b/lib/bunko/models/post_type_methods.rb
@@ -10,7 +10,16 @@ module Bunko
         has_many :posts, dependent: :restrict_with_error
 
         # Validations
-        validates :name, presence: true, uniqueness: true
+        # Name format mirrors the config DSL rules (Bunko::Configuration#post_type).
+        # Enforced at the model level too, since records can be created outside the
+        # DSL (console, seeds, admin UIs) and generated views build route helper
+        # names from post_type.name.
+        validates :name, presence: true, uniqueness: true,
+          format: {
+            with: /\A[a-z0-9_]+\z/,
+            message: "must contain only lowercase letters, numbers, and underscores"
+          },
+          length: {maximum: 100}
         validates :title, presence: true
       end
     end

--- a/lib/tasks/templates/views/collections/index.html.erb.tt
+++ b/lib/tasks/templates/views/collections/index.html.erb.tt
@@ -11,7 +11,7 @@
           <h2>
             <% if is_collection %>
             <%# Collections link to canonical PostType URLs %>
-            <%%= link_to post.title, send("#{post.post_type.name.singularize}_path", post.slug) %>
+            <%%= link_to post.title, public_send("#{post.post_type.name.singularize}_path", post.slug) %>
             <% else %>
             <%# PostTypes link to their own show page %>
             <%%= link_to post.title, <%= path_helper %>(post.slug) %>

--- a/test/dummy/app/views/all_content/index.html.erb
+++ b/test/dummy/app/views/all_content/index.html.erb
@@ -7,7 +7,7 @@
         <article class="post-preview">
           <h2>
             <%# Collections link to canonical PostType URLs %>
-            <%= link_to post.title, send("#{post.post_type.name.singularize}_path", post.slug) %>
+            <%= link_to post.title, public_send("#{post.post_type.name.singularize}_path", post.slug) %>
           </h2>
 
           <div class="post-meta">

--- a/test/dummy/app/views/long_reads/index.html.erb
+++ b/test/dummy/app/views/long_reads/index.html.erb
@@ -7,7 +7,7 @@
         <article class="post-preview">
           <h2>
             <%# Collections link to canonical PostType URLs %>
-            <%= link_to post.title, send("#{post.post_type.name.singularize}_path", post.slug) %>
+            <%= link_to post.title, public_send("#{post.post_type.name.singularize}_path", post.slug) %>
           </h2>
 
           <div class="post-meta">

--- a/test/models/post_type_test.rb
+++ b/test/models/post_type_test.rb
@@ -25,6 +25,27 @@ class PostTypeTest < ActiveSupport::TestCase
     assert_includes duplicate.errors[:name], "has already been taken"
   end
 
+  test "rejects names with characters outside lowercase letters, numbers, and underscores" do
+    ["Blog", "case-study", "blog posts", "blog/admin", "blog;drop", "blog_path "].each do |invalid_name|
+      post_type = PostType.new(name: invalid_name, title: "Test")
+      refute post_type.valid?, "expected name #{invalid_name.inspect} to be invalid"
+      assert_includes post_type.errors[:name], "must contain only lowercase letters, numbers, and underscores"
+    end
+  end
+
+  test "allows names with lowercase letters, numbers, and underscores" do
+    %w[blog case_study docs2].each do |valid_name|
+      post_type = PostType.new(name: valid_name, title: "Test")
+      assert post_type.valid?, "expected name #{valid_name.inspect} to be valid: #{post_type.errors.full_messages}"
+    end
+  end
+
+  test "rejects names longer than 100 characters" do
+    post_type = PostType.new(name: "a" * 101, title: "Test")
+    refute post_type.valid?
+    assert post_type.errors[:name].any? { |e| e.include?("too long") }
+  end
+
   test "allows different names for different post types" do
     PostType.create!(name: "blog", title: "Blog")
 
@@ -113,13 +134,14 @@ class PostTypeTest < ActiveSupport::TestCase
     assert_equal "case_study", post_type.name
   end
 
-  test "name is case sensitive for uniqueness" do
+  test "uppercase name variants are rejected by format validation" do
     PostType.create!(name: "blog", title: "Blog")
 
-    # Different case - should be considered different in most DBs
-    # But this depends on DB collation settings
+    # Format validation only allows lowercase, so case-variant duplicates
+    # (e.g. "BLOG" vs "blog") cannot exist regardless of DB collation
     uppercase = PostType.new(name: "BLOG", title: "BLOG")
-    assert uppercase.valid?
+    refute uppercase.valid?
+    assert_includes uppercase.errors[:name], "must contain only lowercase letters, numbers, and underscores"
   end
 
   test "handles very long titles" do


### PR DESCRIPTION
Hardens the post_type.name → route helper path used by generated collection views.

## What changed
- `PostType.name` now validates format (`/\A[a-z0-9_]+\z/`) and length (max 100) at the model level, mirroring the config DSL rules. Records created via console, seeds, or admin UIs were previously unconstrained.
- Generated index views (and committed dummy copies) call `public_send` instead of `send` when building route helpers from `post_type.name`, so private view-context methods can't be invoked.

## Deploy / QA notes
None — existing valid PostTypes are unaffected. Apps with previously generated views keep their old `send` call until regenerated.

## Test coverage
New model tests for invalid characters, valid names, and length; updated the case-sensitivity uniqueness test (uppercase is now rejected by format). 351 runs, 0 failures; standardrb clean.

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)