### PR TITLE
Stop leaking setup instructions in public 404 responses

### DIFF
--- a/lib/bunko/controllers/collection.rb
+++ b/lib/bunko/controllers/collection.rb
@@ -48,8 +48,7 @@ module Bunko
           # Single PostType collection
           @post_type = PostType.find_by(name: @collection_name)
           unless @post_type
-            render plain: "PostType '#{@collection_name}' not found in database. Run: rails bunko:setup[#{@collection_name}]", status: :not_found
-            return
+            bunko_not_found!("PostType '#{@collection_name}' not found in database. Run: rails bunko:setup[#{@collection_name}]")
           end
 
           base_query = post_model.published.by_post_type(@collection_name)
@@ -62,8 +61,7 @@ module Bunko
             base_query = base_query.instance_exec(&collection_config[:scope])
           end
         else
-          render plain: "Collection '#{@collection_name}' not found. Add it to config/initializers/bunko.rb", status: :not_found
-          return
+          bunko_not_found!("Collection '#{@collection_name}' not found. Add it to config/initializers/bunko.rb")
         end
 
         # Apply ordering
@@ -83,30 +81,35 @@ module Bunko
 
         # Collections should not have show routes (posts are accessed via their canonical PostType URL)
         if collection_config
-          render plain: "Posts in this collection can only be accessed through their PostType URL. This collection only supports index.", status: :not_found
-          return
+          bunko_not_found!("Posts in collection '#{@collection_name}' can only be accessed through their PostType URL. This collection only supports index.")
         end
 
         if post_type_config
           # Single PostType collection
           @post_type = PostType.find_by(name: @collection_name)
           unless @post_type
-            render plain: "PostType '#{@collection_name}' not found in database. Run: rails bunko:setup[#{@collection_name}]", status: :not_found
-            return
+            bunko_not_found!("PostType '#{@collection_name}' not found in database. Run: rails bunko:setup[#{@collection_name}]")
           end
 
           base_query = post_model.published.by_post_type(@collection_name)
         else
-          render plain: "Collection '#{@collection_name}' not found. Add it to config/initializers/bunko.rb", status: :not_found
-          return
+          bunko_not_found!("Collection '#{@collection_name}' not found. Add it to config/initializers/bunko.rb")
         end
 
         # Find post by slug within this collection
         @post = base_query.find_by(slug: params[:slug])
 
         unless @post
-          render plain: "Post not found", status: :not_found
+          bunko_not_found!("Post with slug '#{params[:slug]}' not found in '#{@collection_name}'")
         end
+      end
+
+      # Raises a standard 404 so the host app's not-found handling applies.
+      # The detailed reason is logged for developers but never sent to visitors,
+      # since these messages reference internal setup commands and config paths.
+      def bunko_not_found!(reason)
+        Rails.logger.warn("[Bunko] #{reason}")
+        raise ActiveRecord::RecordNotFound, reason
       end
 
       def post_model

--- a/test/controllers/bunko_collection_controller_test.rb
+++ b/test/controllers/bunko_collection_controller_test.rb
@@ -54,7 +54,8 @@ class BunkoCollectionControllerTest < ActionDispatch::IntegrationTest
     # Test with a collection that doesn't have a PostType or Collection configured
     get "/nonexistent"
     assert_response :not_found
-    assert_match(/Collection 'nonexistent' not found/, response.body)
+    # Internal setup guidance must not leak to visitors (logged instead)
+    assert_no_match(/bunko:setup|initializers/, response.body)
   end
 
   test "index shows all published posts for the collection" do
@@ -103,7 +104,8 @@ class BunkoCollectionControllerTest < ActionDispatch::IntegrationTest
     # Test with a collection that doesn't have a PostType or Collection configured
     get "/nonexistent/any-slug"
     assert_response :not_found
-    assert_match(/Collection 'nonexistent' not found/, response.body)
+    # Internal setup guidance must not leak to visitors (logged instead)
+    assert_no_match(/bunko:setup|initializers/, response.body)
   end
 
   test "show finds post by slug" do


### PR DESCRIPTION
Public 404s from collection controllers no longer reveal internal tooling.

## Problem
Not-found paths in `Bunko::Controllers::Collection` rendered plain-text bodies like "PostType 'blog' not found in database. Run: rails bunko:setup[blog]" — exposing rake commands and config paths to anonymous visitors.

## What changed
All not-found paths now raise `ActiveRecord::RecordNotFound`, so the host app's standard 404 handling applies. The detailed reason is logged with `Rails.logger.warn("[Bunko] ...")` so developers still get the guidance.

## Deploy / QA notes
Visitor-facing 404s switch from plain-text messages to the app's 404 page. In development, the exception message (with guidance) shows on the error page as usual.

## Test coverage
Updated controller tests assert 404 status and that `bunko:setup`/initializer hints never appear in the response body. 348 runs, 0 failures; standardrb clean.

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)