### PR TITLE
fix: correct malformed pagination style attribute

### DIFF
--- a/lib/tasks/templates/views/collections/index.html.erb.tt
+++ b/lib/tasks/templates/views/collections/index.html.erb.tt
@@ -45,7 +45,7 @@
     </div>
 
     <%% if @pagination[:total_pages] > 1 %>
-      <section class="pagination" style=display: flex; justify-content: space-between;">
+      <section class="pagination" style="display: flex; justify-content: space-between;">
         <%% if @pagination[:prev_page] %>
           <%%= link_to "← Previous", <%= index_path_helper %>(page: @pagination[:current_page] - 1), class: "pagination-prev" %>
         <%% end %>


### PR DESCRIPTION
Closes #61

Fixed malformed HTML in the generated collection index template.

The style attribute was missing the opening quote, resulting in invalid HTML being generated.