### PR TITLE
Fix malformed style attribute in pagination template

### DIFF
--- a/lib/tasks/templates/views/collections/index.html.erb.tt
+++ b/lib/tasks/templates/views/collections/index.html.erb.tt
@@ -45,7 +45,7 @@
     </div>
 
     <%% if @pagination[:total_pages] > 1 %>
-      <section class="pagination" style=display: flex; justify-content: space-between;">
+      <section class="pagination" style="display: flex; justify-content: space-between;">
         <%% if @pagination[:prev_page] %>
           <%%= link_to "← Previous", <%= index_path_helper %>(page: @pagination[:current_page] - 1), class: "pagination-prev" %>
         <%% end %>


### PR DESCRIPTION
## Summary
Fixed a syntax error in the pagination section of the collections index template where the `style` attribute was missing opening quotes.

closes #61

## Changes
- **lib/tasks/templates/views/collections/index.html.erb.tt**: Corrected malformed `style` attribute from `style=display: flex; justify-content: space-between;">` to `style="display: flex; justify-content: space-between;">`

## Details
The pagination section's inline style attribute was missing the opening quote after `style=`, which would cause invalid HTML to be generated in the template output. This fix ensures the CSS flexbox properties are properly applied to the pagination container.

https://claude.ai/code/session_01WTCZiEz2TKhKJ8isSRHH1S