### PR TITLE
Add security policy and update reporting guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,9 @@ bundle exec rake build
 bundle exec rake release
 ```
 
+**On each release, also update:**
+- `SECURITY.md` - Update the "Supported Versions" table to reflect the currently supported release(s).
+
 ## Project Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -755,7 +755,7 @@ RAILS_VERSION="~> 8.1.0" bundle exec rake brakeman:vendor_scan
 
 **Reporting Security Issues:**
 
-Please report vulnerabilities privately via email rather than public GitHub issues.
+Please report vulnerabilities privately — see [SECURITY.md](SECURITY.md) — rather than via public GitHub issues.
 
 **Security Best Practices:**
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Supported Versions
+
+Bunko is pre-1.0; only the latest release receives security fixes.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.2.x   | :white_check_mark: |
+| < 0.2   | :x:                |
+
+## Reporting a Vulnerability
+
+Please report vulnerabilities **privately**, not via public issues:
+
+- Preferred: open a [GitHub Security Advisory](https://github.com/kanejamison/bunko/security/advisories/new).
+- Or email the maintainer at 918780+kanejamison@users.noreply.github.com.
+
+We aim to acknowledge reports within a few days and will coordinate a fix and disclosure with you.
+
+## Security Model
+
+Bunko is a content-routing layer, not a security boundary:
+
+- **Public controllers are read-only by design.** Generated collection and page controllers only expose `index`/`show`.
+- **Writes are the host application's responsibility.** Bunko ships no admin UI and no authentication or authorization. Any content editing — including an Avo (or other) admin — must be secured by the host app.
+- **Sanitize and scope your own content.** Bunko does not escape post content for you; use Rails' `sanitize` helpers and strong parameters as appropriate.


### PR DESCRIPTION
## Summary

Establishes a formal security policy for the Bunko project and updates documentation to direct users to the new policy for vulnerability reporting.

## Changes

- **Added SECURITY.md** - New security policy document that includes:
  - Supported versions table (currently 0.2.x only, as project is pre-1.0)
  - Private vulnerability reporting instructions (GitHub Security Advisory or email)
  - Security model clarification explaining Bunko's design boundaries:
    - Public controllers are read-only by design
    - Authentication/authorization is the host application's responsibility
    - Content sanitization must be handled by the host app using Rails helpers

- **Updated README.md** - Modified security reporting section to reference the new SECURITY.md file instead of just mentioning email reporting

## Implementation Details

The security policy clearly communicates Bunko's threat model and design philosophy: it is a content-routing layer, not a security boundary. This aligns with the project's core philosophy of being "database, editor, and view layer agnostic" with "no opinions on authentication, authorization, or admin UI."

The policy establishes a responsible disclosure process while setting clear expectations about what security responsibilities fall to Bunko versus the host application.

https://claude.ai/code/session_01Rk92fZskUpF9CEQ9qzd5uR