### PR TITLE
Security: Harden gemspec with MFA requirement and metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Building toward 1.0.0 release. Using 0.x versions during active development.
 **Fixed:**
 - `PagesController` now reads the page slug from the route's `defaults: {page: ...}` (via `params[:page]`) instead of parsing `request.path`, fixing 404s for root-path pages (`bunko_page :home, path: "/"`) and pages with custom paths (`bunko_page :about, path: "about-us"`) (#57)
 
+**Security:**
+- Gemspec hardening: require MFA for RubyGems pushes (`rubygems_mfa_required`) and add `source_code_uri` and `bug_tracker_uri` metadata.
+
 ## [0.2.0] - 2025-11-14
 
 First functional release of Bunko - a lightweight Rails CMS based on the "one model, infinite collections" philosophy.

--- a/bunko.gemspec
+++ b/bunko.gemspec
@@ -15,7 +15,10 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 4.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = "https://github.com/kanejamison/bunko/blob/main/CHANGELOG.md"
+  spec.metadata["bug_tracker_uri"] = "#{spec.homepage}/issues"
+  spec.metadata["rubygems_mfa_required"] = "true"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
## Summary

Hardens the gem's security posture by requiring MFA for RubyGems pushes and adding important metadata URIs to the gemspec.

## Changes

- **MFA Requirement**: Added `rubygems_mfa_required = "true"` to gemspec to enforce multi-factor authentication for all gem pushes
- **Metadata URIs**: Added `source_code_uri` (pointing to homepage) and `bug_tracker_uri` (pointing to `/issues`) for better discoverability
- **Changelog**: Updated CHANGELOG.md with security improvements note

## Implementation Details

These changes follow RubyGems best practices:
- MFA requirement prevents unauthorized gem releases even if credentials are compromised
- Source code and bug tracker URIs are displayed on rubygems.org, improving user experience and security transparency
- All metadata uses the existing `spec.homepage` variable for consistency and maintainability

https://claude.ai/code/session_01Rbmv18Gwr12r5CYH9SUvcn